### PR TITLE
Fix bug when initializing a profile with constant total number of particles

### DIFF
--- a/src/adsorption/pore.rs
+++ b/src/adsorption/pore.rs
@@ -164,7 +164,6 @@ where
 
     pub fn update_bulk(mut self, bulk: &State<U, DFT<F>>) -> Self {
         self.profile.bulk = bulk.clone();
-        self.profile.chemical_potential = bulk.chemical_potential(Contributions::Total);
         self.grand_potential = None;
         self.interfacial_tension = None;
         self

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -474,16 +474,6 @@ where
         // Read from profile
         let temperature = self.temperature.to_reduced(U::reference_temperature())?;
         let mut density = self.density.to_reduced(U::reference_density())?;
-        // let lambda_de_broglie = self
-        //     .dft
-        //     .functional
-        //     .ideal_gas()
-        //     .de_broglie_wavelength(temperature, self.bulk.eos.components());
-        // let mut mu_comp = self
-        //     .chemical_potential
-        //     .to_reduced(U::reference_molar_energy())?
-        //     / temperature
-        //     - lambda_de_broglie;
         let mut chemical_potential = self.reduced_chemical_potential()?;
         let mut bulk = self.bulk.clone();
 

--- a/src/python/profile.rs
+++ b/src/python/profile.rs
@@ -81,7 +81,7 @@ macro_rules! impl_profile {
 
             #[getter]
             fn get_chemical_potential(&self) -> PySIArray1 {
-                PySIArray1::from(self.0.profile.chemical_potential.clone())
+                PySIArray1::from(self.0.profile.chemical_potential())
             }
 
             #[getter]


### PR DESCRIPTION
This removes the `chemical_potential` field from `DFTProfile` and replaces it with a getter that calculates the chemical potential from the associated bulk state, thus avoiding redundancies and making the code easier to maintain.